### PR TITLE
调整server酱推送消息格式，避免消息显示不全

### DIFF
--- a/.github/workflows/auto_clean.yaml
+++ b/.github/workflows/auto_clean.yaml
@@ -1,0 +1,15 @@
+name: 'workflows日志自动清理'
+
+on:
+  schedule:
+    - cron: '0 0 */3 * *'
+  workflow_dispatch:
+
+jobs:
+  del_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: GitRML/delete-workflow-runs@main
+        with:
+          retain_days: '3'

--- a/.github/workflows/auto_push.yml
+++ b/.github/workflows/auto_push.yml
@@ -1,0 +1,32 @@
+name: 自动push防止Actions自动停止
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 0 1,15 * *'
+    repository_dispatch:
+        types: start_action
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        if: github.event.repository.owner.id == github.event.sender.id || ! github.event.sender.id || github.actor == 'StoneForests'
+
+        steps:
+            - name: Getting the repo
+              uses: actions/checkout@v3
+
+            - name: Re setting the url for `origin`
+              run: |
+                  git remote set-url origin https://${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            - name: Adding git info
+              run: |
+                  git config --global user.name "StoneForests"
+                  git config --global user.email "5436513+StoneForests@users.noreply.github.com"
+            - name: Creating an empty commit
+              run: |
+                  git commit --allow-empty -m "Auto amazing commit"
+
+            - name: Finilly pushing the repo
+              run: |
+                  git push origin master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,11 @@
 name: Run
 
 on:
-  workflow_dispatch:
-  repository_dispatch:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 22,14 * * *"
+    watch:
+        types: [started]
 
 jobs:
   build:

--- a/Program.cs
+++ b/Program.cs
@@ -99,7 +99,7 @@ for (int i = 0; i < _conf.Users.Length; i++)
         space += Deserialize<YdNoteRsp>(result).Space;
     }
 
-    await Notify($"有道云笔记{title}签到成功，共获得空间 {space / 1048576} M");
+    await Notify($"有道云笔记{title}签到成功，共获得空间{space / 1048576}M");
 }
 Console.WriteLine("签到运行完毕");
 

--- a/Program.cs
+++ b/Program.cs
@@ -192,7 +192,7 @@ async Task Notify(string msg, bool isFailed = false)
     Console.WriteLine(msg);
     if (_conf.ScType == "Always" || (isFailed && _conf.ScType == "Failed"))
     {
-        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?title=有道云笔记账号&desp={msg}");
+        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?title=有道云笔记签到&desp={msg}");
     }
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -99,7 +99,7 @@ for (int i = 0; i < _conf.Users.Length; i++)
         space += Deserialize<YdNoteRsp>(result).Space;
     }
 
-    await Notify($"有道云笔记{title}签到成功，共获得空间{space / 1048576}M");
+    await Notify($"有道云笔记{title}签到成功，共获得空间 {space / 1048576} M");
 }
 Console.WriteLine("签到运行完毕");
 
@@ -192,7 +192,7 @@ async Task Notify(string msg, bool isFailed = false)
     Console.WriteLine(msg);
     if (_conf.ScType == "Always" || (isFailed && _conf.ScType == "Failed"))
     {
-        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?text={msg}");
+        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?title=有道云笔记账号&desp={msg}");
     }
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -192,7 +192,7 @@ async Task Notify(string msg, bool isFailed = false)
     Console.WriteLine(msg);
     if (_conf.ScType == "Always" || (isFailed && _conf.ScType == "Failed"))
     {
-        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?text={msg}");
+        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?title=有道云笔记签到&desp={msg}");
     }
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -192,7 +192,7 @@ async Task Notify(string msg, bool isFailed = false)
     Console.WriteLine(msg);
     if (_conf.ScType == "Always" || (isFailed && _conf.ScType == "Failed"))
     {
-        await _scClient.GetAsync($"https://sc.ftqq.com/{_conf.ScKey}.send?title=有道云笔记签到&desp={msg}");
+        await _scClient.GetAsync($"https://sctapi.ftqq.com/{_conf.ScKey}.send?title=有道云笔记签到&desp={msg}");
     }
 }
 


### PR DESCRIPTION
由于server酱标题长度限制，因此原有推送消息的格式会导致显示不全，进行了相应调整
调整前：
![image](https://github.com/user-attachments/assets/2912da78-caee-4254-adea-bdc92ec3a027)
调整后：
![image](https://github.com/user-attachments/assets/fa30d9d3-b4dc-4b06-ac43-988f27bb1aad)
